### PR TITLE
Removed explicit protocol from font import

### DIFF
--- a/static/app/styles/main.scss
+++ b/static/app/styles/main.scss
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:300,400,700,800);
 
 @import "bourbon/bourbon";
 @import "neat/neat";


### PR DESCRIPTION
This fixes an issue where the font doesn't load under https. Sass has supported this since 2012. Also added a newline at end of file.
